### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Local NixOS Configs
 
-This repo contains the set up of my local system using [nix expressions](https://nixos.wiki/wiki/Overview_of_the_Nix_Language).
+This repo contains the set up of my local system using [nix expressions](https://wiki.nixos.org/wiki/Overview_of_the_Nix_Language).
 
 One may have to face many perspectives to understand what Nix is.
 Nix is a novel paradigm that provides a wat to programmatically declare a system.
@@ -24,7 +24,7 @@ No more *apt-get install this* or *rpm -i that*. Just use nix expressions to dec
 need and (hopefully) it'll be there available in your system.
 This repository is based in two major components of Nix ecossystem: Nix Flakes and Home Manager.
 
-[Nix Flakes](https://nixos.wiki/wiki/Flakes) is a directory tree with a nix file named *flake.nix*
+[Nix Flakes](https://wiki.nixos.org/wiki/Flakes) is a directory tree with a nix file named *flake.nix*
 that follows a specific schema to describe inputs and outputs. Inputs are the dependencies of your build
 and outputs are your packages, systems, development environments, etc.
 

--- a/home/michel/desktop/wayland/_common/browsers.nix
+++ b/home/michel/desktop/wayland/_common/browsers.nix
@@ -53,9 +53,9 @@
 
             "NixOS Wiki" = {
               urls = [{
-                template = "https://nixos.wiki/index.php?search={searchTerms}";
+                template = "https://wiki.nixos.org/index.php?search={searchTerms}";
               }];
-              iconUpdateURL = "https://nixos.wiki/favicon.png";
+              iconUpdateURL = "https://wiki.nixos.org/favicon.png";
               updateInterval = 24 * 60 * 60 * 1000; # every day
               definedAliases = [ "@nw" ];
             };

--- a/home/michel/desktop/wayland/_common/qutebrowser.nix
+++ b/home/michel/desktop/wayland/_common/qutebrowser.nix
@@ -12,7 +12,7 @@ in {
       wiki =
         "https://en.wikipedia.org/wiki/Special:Search?search={}&go=Go&ns0=1";
       aw = "https://wiki.archlinux.org/?search={}";
-      # nw = "https://nixos.wiki/index.php?search={}";
+      # nw = "https://wiki.nixos.org/index.php?search={}";
       nw = "https://wiki.nixos.org/w/index.php?search={}";
       nd = "https://discourse.nixos.org/search?q={}";
       gh = "https://github.com/search?q={}";


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️